### PR TITLE
fix: include JS artifacts in Nix package

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,12 @@ This project uses the format: `<vite-plus-version>-nix.<revision>`
 
 ## [Unreleased]
 
+## [0.1.15-alpha.2-nix.2] - 2026-03-28
+
+### Fixed
+
+* Include JS artifacts (dist/bin.js) from npm tarball in Nix package
+
 ## [0.1.15-alpha.2-nix.1] - 2026-03-28
 
 ### Changed
@@ -82,7 +88,8 @@ This project uses the format: `<vite-plus-version>-nix.<revision>`
 - Automated version update workflow
 - Automatic tag creation on release
 
-[Unreleased]: https://github.com/naitokosuke/vp-nix/compare/0.1.15-alpha.2-nix.1...HEAD
+[Unreleased]: https://github.com/naitokosuke/vp-nix/compare/0.1.15-alpha.2-nix.2...HEAD
+[0.1.15-alpha.2-nix.2]: https://github.com/naitokosuke/vp-nix/compare/0.1.15-alpha.2-nix.1...0.1.15-alpha.2-nix.2
 [0.1.15-alpha.2-nix.1]: https://github.com/naitokosuke/vp-nix/compare/0.1.15-alpha.1-nix.1...0.1.15-alpha.2-nix.1
 [0.1.15-alpha.1-nix.1]: https://github.com/naitokosuke/vp-nix/compare/0.1.15-alpha.0-nix.1...0.1.15-alpha.1-nix.1
 [0.1.15-alpha.0-nix.1]: https://github.com/naitokosuke/vp-nix/compare/0.1.14-alpha.1-nix.1...0.1.15-alpha.0-nix.1

--- a/flake.nix
+++ b/flake.nix
@@ -50,6 +50,12 @@
             hash = "sha256-oUi2YO6vQJr3pEBpA/k9DmcTpeua3K9xodcy8ePMNSI=";
           };
 
+          # JS artifacts from the npm package (vp binary expects node_modules/vite-plus/dist/bin.js)
+          vitePlusNpm = pkgs.fetchurl {
+            url = "https://registry.npmjs.org/vite-plus/-/vite-plus-${version}.tgz";
+            hash = "sha256-thIKhIJ9y4iO81wMADgM++pWzxm7UbO7JTFyy5yO8pk=";
+          };
+
           fakeCurl = pkgs.writeShellScriptBin "curl" ''
             for arg in "$@"; do url="$arg"; done
             case "$url" in
@@ -88,6 +94,11 @@
               --replace-fail 'members = ["bench", "crates/*", "packages/cli/binding"]' \
                              'members = ["crates/*"]'
             sed -i '/path = "\.\/rolldown\//d' Cargo.toml
+          '';
+
+          postInstall = ''
+            mkdir -p $out/node_modules/vite-plus
+            tar xzf ${vitePlusNpm} --strip-components=1 -C $out/node_modules/vite-plus
           '';
 
           doCheck = false;


### PR DESCRIPTION
## Summary

* Fix runtime error where `vp` binary fails because `dist/bin.js` is missing from the Nix store output
* Fetch the npm tarball via `fetchurl` and extract it to `$out/node_modules/vite-plus/` in `postInstall`

Closes #16

## Test plan

* [x] `nix build .#vite-plus` succeeds
* [x] `result/node_modules/vite-plus/dist/bin.js` exists in the output
* [x] `nix run .#vite-plus -- --version` runs without error

🤖 Generated with [Claude Code](https://claude.com/claude-code)