### PR TITLE
fix: update npm tarball hash in update-vp workflow

### DIFF
--- a/.github/workflows/update-vp.yml
+++ b/.github/workflows/update-vp.yml
@@ -92,7 +92,26 @@ jobs:
           # Update source hash (only first occurrence)
           $GSED -i "0,/hash = \"sha256-[^\"]*\"/s||hash = \"$NEW_HASH\"|" flake.nix
 
-          echo "Updated to version $NEW_VERSION with hash $NEW_HASH"
+          echo "Updated source to version $NEW_VERSION with hash $NEW_HASH"
+
+          # Get new npm tarball hash
+          echo "Fetching npm tarball hash for version $NEW_VERSION..."
+          NPM_PREFETCH_HASH=$(nix-prefetch-url "https://registry.npmjs.org/vite-plus/-/vite-plus-${NEW_VERSION}.tgz")
+          if [ -z "$NPM_PREFETCH_HASH" ]; then
+            echo "Error: Failed to prefetch npm tarball"
+            exit 1
+          fi
+          NPM_HASH=$(nix hash to-sri --type sha256 "$NPM_PREFETCH_HASH")
+          if [ -z "$NPM_HASH" ]; then
+            echo "Error: Failed to convert npm hash to SRI format"
+            exit 1
+          fi
+          echo "Got npm hash: $NPM_HASH"
+
+          # Update npm tarball hash (vitePlusNpm - the hash after "registry.npmjs.org")
+          $GSED -i '/registry\.npmjs\.org/{n;s|hash = "sha256-[^"]*"|hash = "'"$NPM_HASH"'"|;}' flake.nix
+
+          echo "Updated npm tarball hash to $NPM_HASH"
 
       - name: Update CHANGELOG.md
         if: steps.check.outputs.needs_update == 'true'


### PR DESCRIPTION
## Summary
- The `update-vp.yml` workflow was only updating the GitHub source hash but not the `vitePlusNpm` fetchurl hash in `flake.nix`
- This caused `nix build` to fail with a hash mismatch error when a new vite-plus version was published on npm
- Added npm tarball prefetch and hash update step to the workflow

Closes #18

## Test plan
- [ ] Trigger the `update-vp` workflow manually via `workflow_dispatch` and verify it completes successfully
- [ ] Confirm both the source hash and npm tarball hash are updated in the generated PR's `flake.nix`

🤖 Generated with [Claude Code](https://claude.com/claude-code)