### PR TITLE
fix: drop obsolete version="0.0.0" replacement in postPatch

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -204,8 +204,6 @@
               --replace-fail 'members = ["bench", "crates/*", "packages/cli/binding"]' \
                              'members = ["crates/*"]'
             sed -i '/path = "\.\/rolldown\//d' Cargo.toml
-            substituteInPlace crates/vite_global_cli/Cargo.toml \
-              --replace-fail 'version = "0.0.0"' 'version = "${version}"'
           '';
 
           postInstall = ''


### PR DESCRIPTION
## Summary
- vite-plus v0.1.22 から upstream が `crates/vite_global_cli/Cargo.toml` に実バージョンを直接書き込むようになり、`version = "0.0.0"` プレースホルダが存在しなくなった
- 結果、`flake.nix` の `--replace-fail` が一致対象を見つけられず `Update vite-plus version` ワークフローの `Verify build` ステップが失敗し、自動更新 PR が作れなくなっていた ([failed run](https://github.com/naitokosuke/vp-nix/actions/runs/26198472348))
- upstream が既に正しい値を持っているので置換ごと削除する

### Failure log (抜粋)
```
ERROR: pattern version\ =\ \"0.0.0\" doesn't match anything in file 'crates/vite_global_cli/Cargo.toml'
```

## Test plan
- [ ] `nix build .#vite-plus --no-link --print-build-logs` がローカルで通る
- [ ] マージ後、`Update vite-plus version` ワークフローを手動トリガし v0.1.22 への更新 PR が作成されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)