### PR TITLE
docs: explain ERR_PNPM_DLX_NO_BIN gotcha for vp create shorthand

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,26 @@ A GitHub Actions workflow (`update-vp.yml`) runs every 12 hours to check for new
 
 Nix builds run inside a sandbox with no network access. The `buildNpmPackage` helper needs a `package-lock.json` to produce a fixed-output derivation of npm dependencies (`npmDepsHash`). Because the upstream vite-plus repository does not ship a lock file suitable for this purpose, this flake maintains its own `package.json` / `package-lock.json` that pins the vite-plus npm tarball. The automated update workflow keeps these files in sync whenever a new version is released.
 
+## Troubleshooting
+
+### `vp create <name>` fails with `ERR_PNPM_DLX_NO_BIN`
+
+```
+[ERR_PNPM_DLX_NO_BIN] No binaries found in create-web
+```
+
+`vp create <name>` expands any unrecognized shorthand to `create-<name>` and runs `pnpm dlx <expanded>` without validating the result. For example, `vp create web` expands to `create-web`, which happens to exist on npm as an unrelated empty package with no executable, so pnpm aborts with `ERR_PNPM_DLX_NO_BIN`.
+
+Use a supported builtin or shorthand instead:
+
+```sh
+vp create --list                 # show valid builtins and shorthands
+vp create vite:application out   # builtin Vite application
+vp create vite out               # shorthand for create-vite
+```
+
+This is upstream vite-plus behavior; see [issue #68](https://github.com/naitokosuke/vp-nix/issues/68).
+
 ## License
 
 MIT


### PR DESCRIPTION
## Summary

- Add a Troubleshooting entry to `README.md` for `ERR_PNPM_DLX_NO_BIN` when `vp create <name>` is called with an unrecognized shorthand
- Explain that vite-plus expands any unknown token to `create-<name>` and `pnpm dlx`'s it (so `vp create web` ends up running an unrelated stub package on npm)
- Point users at `vp create --list` and the builtin templates

Closes #68

## Test plan

- [x] `vp create web testdir` reproduces `[ERR_PNPM_DLX_NO_BIN] No binaries found in create-web`
- [x] `vp create --list` shows `vite`, `@tanstack/start`, `next-app`, `nuxt`, `react-router`, `svelte`, `vue` as the supported shorthands
- [ ] README renders correctly on GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)