### PR TITLE
fix(ci): sync Rust toolchain pin with upstream rust-toolchain.toml in update-vp workflow

### DIFF
--- a/.github/workflows/update-vp.yml
+++ b/.github/workflows/update-vp.yml
@@ -73,12 +73,42 @@ jobs:
 
       - name: Update flake.nix
         if: steps.check.outputs.needs_update == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
         run: |
           set -e
           NEW_VERSION="${{ steps.latest.outputs.version }}"
 
           # Use GNU sed via Nix for compatibility with macOS
           GSED="nix run nixpkgs#gnused --"
+
+          # Sync the pinned Rust toolchain with upstream rust-toolchain.toml.
+          # vite-plus bumps its required nightly from time to time (e.g. v0.1.23
+          # moved to nightly-2026-05-24 for the c_variadic VaList::next_arg API).
+          # Without this, the new version fails to compile against a stale
+          # toolchain and the "Verify build" step below fails.
+          echo "Syncing Rust toolchain from upstream rust-toolchain.toml..."
+          RUST_CHANNEL=$(gh api "repos/voidzero-dev/vite-plus/contents/rust-toolchain.toml?ref=v${NEW_VERSION}" \
+            -H "Accept: application/vnd.github.raw" \
+            | grep -E '^channel' \
+            | sed -E 's/.*"nightly-([0-9]{4}-[0-9]{2}-[0-9]{2})".*/\1/')
+          if [ -z "$RUST_CHANNEL" ]; then
+            echo "Error: Could not determine Rust nightly channel from upstream rust-toolchain.toml"
+            exit 1
+          fi
+          echo "Upstream Rust nightly channel: nightly-$RUST_CHANNEL"
+
+          CURRENT_CHANNEL=$(grep -oE 'nightly\."[0-9]{4}-[0-9]{2}-[0-9]{2}"' flake.nix | head -1 | grep -oE '[0-9]{4}-[0-9]{2}-[0-9]{2}')
+          if [ "$CURRENT_CHANNEL" != "$RUST_CHANNEL" ]; then
+            echo "Updating Rust toolchain pin: nightly-$CURRENT_CHANNEL -> nightly-$RUST_CHANNEL"
+            # Update both the documenting comment (nightly-DATE) and the pin (nightly."DATE")
+            $GSED -i -E "s|nightly-[0-9]{4}-[0-9]{2}-[0-9]{2}|nightly-$RUST_CHANNEL|g" flake.nix
+            $GSED -i -E "s|nightly\.\"[0-9]{4}-[0-9]{2}-[0-9]{2}\"|nightly.\"$RUST_CHANNEL\"|" flake.nix
+            # Refresh rust-overlay so the new nightly toolchain is available
+            nix flake update rust-overlay
+          else
+            echo "Rust toolchain already up to date (nightly-$RUST_CHANNEL)"
+          fi
 
           # Update version (only first occurrence)
           $GSED -i "0,/version = \"[^\"]*\"/s//version = \"$NEW_VERSION\"/" flake.nix


### PR DESCRIPTION
## What

Makes the scheduled `update-vp.yml` workflow keep the pinned Rust nightly toolchain in sync with upstream `rust-toolchain.toml`, so auto-generated update PRs build green on their own.

## Why

The workflow bumped the vite-plus version and recomputed the Nix hashes, but never touched the Rust toolchain pin in `flake.nix` (or `rust-overlay` in `flake.lock`). When upstream bumps its nightly, the auto PR carries a stale toolchain and fails at **Verify build**.

This already happened with **v0.1.23** (`nightly-2025-12-11` → `nightly-2026-05-24`, new `c_variadic` `VaList::next_arg` API):

```
error[E0599]: no method named `next_arg` found for struct `VaList<'a>`
error: could not compile `fspy_preload_unix` (lib) due to 7 previous errors
```

`#70` is the original incident; `#72` fixed v0.1.23 manually. This PR prevents recurrence.

## Change

In the `Update flake.nix` step, before computing hashes / verifying the build:

1. Fetch upstream `rust-toolchain.toml` for the target tag (raw) and extract the `nightly-YYYY-MM-DD` channel.
2. If it differs from the pin in `flake.nix`, update both the pin and its documenting comment.
3. Run `nix flake update rust-overlay` so the newly required nightly is available.

`GH_TOKEN` is added to the step for the `gh api` call.

## Verification

The workflow logic only runs when the workflow runs, so `ci.yml` does not exercise it. Validated locally instead:

- Channel extraction from upstream `rust-toolchain.toml`: v0.1.23 → `2026-05-24`, v0.1.22 → `2025-12-11` ✓
- Rewrite of the pin + comment in a copy of `main`'s `flake.nix`: `nightly-2025-12-11` → `nightly-2026-05-24` ✓
- `actionlint` passes (no errors) ✓

Ordering note: the toolchain sync runs *before* the `pnpmDepsHash` / `cargoVendorHash` steps, because `cargo vendor` output (and thus `cargoVendorHash`) depends on the cargo version.

Closes #73
