### PR TITLE
fix(ci): verify build on scheduled update-vp run even when no update is needed

### DIFF
--- a/.github/workflows/update-vp.yml
+++ b/.github/workflows/update-vp.yml
@@ -220,6 +220,19 @@ jobs:
           nix build .#vite-plus --no-link --print-build-logs
           echo "Build successful"
 
+      # When no update is needed the steps above are skipped, so the scheduled
+      # run would report success without ever building anything. Always verify
+      # that the currently pinned version still builds, so toolchain drift
+      # (e.g. upstream requiring a newer nightly than flake.nix pins) is caught
+      # here instead of silently passing.
+      - name: Verify current build
+        if: steps.check.outputs.needs_update == 'false'
+        run: |
+          set -e
+          echo "No update needed; verifying the currently pinned build still works..."
+          nix build .#vite-plus --no-link --print-build-logs
+          echo "Current build successful"
+
       - name: Create Pull Request
         if: steps.check.outputs.needs_update == 'true'
         uses: peter-evans/create-pull-request@v8


### PR DESCRIPTION
Closes #76

## Problem

`.github/workflows/update-vp.yml` only runs `nix build` inside the `needs_update == 'true'` branch. When the pinned version already matches the latest upstream tag, every step is skipped and the scheduled run reports **success without building anything**.

This let toolchain drift go undetected: building `vite-plus >= 0.1.23` against a stale nightly fails to compile `fspy_preload_unix` with

```
error[E0599]: no method named `next_arg` found for struct `VaList<'a>`
error: could not compile `fspy_preload_unix` (lib) due to 7 previous errors
```

because the `c_variadic` `VaList::next_arg` API requires `nightly-2026-05-24`. Such a regression would never surface on the routine 12-hourly schedule — only on a version bump or a manual re-run.

## Change

Add an unconditional **Verify current build** step (runs when `needs_update == 'false'`) so every scheduled run still exercises `nix build .#vite-plus`. Toolchain drift is now caught in CI instead of silently passing.

The existing update path (`needs_update == 'true'`) is unchanged.

## Test plan

- [ ] CI on this PR builds `vite-plus` successfully (it actually runs the build, since the workflow file changed).
- [ ] After merge, the next scheduled `Update vite-plus version` run executes the new "Verify current build" step instead of skipping straight to success.

🤖 Generated with [Claude Code](https://claude.com/claude-code)