### PR TITLE
refactor: tidy flake / CI / docs and fix npm->pnpm drift

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,11 +39,10 @@ jobs:
         include:
           - os: macos-latest   # aarch64-darwin
             system: aarch64-darwin
-          # Additional platforms can be enabled once binary hashes are filled in:
-          # - os: macos-13       # x86_64-darwin
-          #   system: x86_64-darwin
-          # - os: ubuntu-latest  # x86_64-linux
-          #   system: x86_64-linux
+          - os: ubuntu-latest  # x86_64-linux
+            system: x86_64-linux
+          # x86_64-darwin (macos-13) and aarch64-linux are defined in the flake
+          # but have no standard GitHub-hosted runners, so they are not built in CI.
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v6
@@ -57,21 +56,25 @@ jobs:
           name: vp-nix
           authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
 
-      - name: Build vite-plus
-        run: nix build .#vite-plus --print-build-logs
-
-      - name: Test vp runs
-        run: nix run .#vite-plus -- --version
+      # nix flake check evaluates all flake outputs and builds this system's
+      # checks. checks.${system}.vite-plus-version already runs `vp --version`,
+      # which depends on the full package build, so this covers build + smoke test.
+      - name: Run flake checks
+        run: nix flake check --print-build-logs
 
   ci-complete:
     runs-on: ubuntu-latest
-    needs: [build]
+    needs: [changes, build]
     if: always()
     steps:
-      - name: Check build result
+      - name: Check results
         run: |
+          if [[ "${{ needs.changes.result }}" == "failure" ]]; then
+            echo "Change detection failed"
+            exit 1
+          fi
           if [[ "${{ needs.build.result }}" == "failure" ]]; then
             echo "Build failed"
             exit 1
           fi
-          echo "CI complete (build: ${{ needs.build.result }})"
+          echo "CI complete (changes: ${{ needs.changes.result }}, build: ${{ needs.build.result }})"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,9 +56,6 @@ jobs:
           name: vp-nix
           authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
 
-      # nix flake check evaluates all flake outputs and builds this system's
-      # checks. checks.${system}.vite-plus-version already runs `vp --version`,
-      # which depends on the full package build, so this covers build + smoke test.
       - name: Run flake checks
         run: nix flake check --print-build-logs
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Unofficial Nix flake for [vite-plus (vp)](https://github.com/voidzero-dev/vite-plus) -- Unified Toolchain for JavaScript.
 
-Currently supports `aarch64-darwin` only.
+The flake defines `aarch64-darwin`, `x86_64-darwin`, `aarch64-linux`, and `x86_64-linux`. CI verifies builds on `aarch64-darwin` and `x86_64-linux`; the other two are not built in CI because no standard GitHub-hosted runners exist for them.
 
 ## Usage
 
@@ -35,15 +35,20 @@ nix profile install github:naitokosuke/vp-nix
 A GitHub Actions workflow (`update-vp.yml`) runs every 12 hours to check for new vite-plus releases. When a new version is found it:
 
 1. Updates the version and source hash in `flake.nix`
-2. Updates `package.json` and `package-lock.json` for the new npm tarball
-3. Recomputes `npmDepsHash` using `prefetch-npm-deps`
-4. Updates `CHANGELOG.md`
-5. Verifies the build passes
-6. Opens a pull request automatically
+2. Syncs the pinned Rust nightly toolchain with the upstream `rust-toolchain.toml`
+3. Updates `pnpm/package.json` and `pnpm/pnpm-lock.yaml`
+4. Recomputes `pnpmDepsHash` and `cargoVendorHash`
+5. Updates `CHANGELOG.md`
+6. Verifies the build passes and opens a pull request automatically
 
-## Why package.json lives in this repository
+## Why the pnpm and vendoring files live in this repository
 
-Nix builds run inside a sandbox with no network access. The `buildNpmPackage` helper needs a `package-lock.json` to produce a fixed-output derivation of npm dependencies (`npmDepsHash`). Because the upstream vite-plus repository does not ship a lock file suitable for this purpose, this flake maintains its own `package.json` / `package-lock.json` that pins the vite-plus npm tarball. The automated update workflow keeps these files in sync whenever a new version is released.
+Nix builds run inside a sandbox with no network access, so all dependencies must be fetched as fixed-output derivations before the build.
+
+- **JavaScript deps:** `fetchPnpmDeps` needs a lock file to produce a reproducible `node_modules` (`pnpmDepsHash`). Because upstream does not ship a lock file suitable for this purpose, this flake maintains its own `pnpm/package.json` / `pnpm/pnpm-lock.yaml` pinning the vite-plus package.
+- **Rust deps:** crates are vendored with `cargo vendor` into a fixed-output derivation (`cargoVendorHash`); this handles a crate that appears from both crates.io and a git source, which the nixpkgs `fetchCargoVendor`/`importCargoLock` helpers cannot.
+
+The automated update workflow keeps all of these in sync whenever a new version is released.
 
 ## License
 

--- a/flake.nix
+++ b/flake.nix
@@ -16,6 +16,8 @@
       rust-overlay,
     }:
     let
+      inherit (nixpkgs) lib;
+
       supportedSystems = [
         "aarch64-darwin"
         "x86_64-darwin"
@@ -23,15 +25,33 @@
         "x86_64-linux"
       ];
 
-      forAllSystems = nixpkgs.lib.genAttrs supportedSystems;
+      forAllSystems = lib.genAttrs supportedSystems;
+
+      # Single source of truth for nixpkgs per system. The rust-overlay is
+      # harmless for the formatter/devShell/checks and keeps every output on
+      # the same package set.
+      pkgsFor =
+        system:
+        import nixpkgs {
+          inherit system;
+          overlays = [ rust-overlay.overlays.default ];
+        };
+
+      # The workspace references packages/cli/binding which depends on
+      # rolldown/ (not present in the source tree). Remove the member and all
+      # rolldown path dependencies so cargo can resolve the workspace. Shared
+      # by the cargo-vendor FOD and the final build so the two cannot drift.
+      patchWorkspace = ''
+        substituteInPlace Cargo.toml \
+          --replace-fail 'members = ["bench", "crates/*", "packages/cli/binding"]' \
+                         'members = ["crates/*"]'
+        sed -i '/path = "\.\/rolldown\//d' Cargo.toml
+      '';
 
       mkVitePlus =
         system:
         let
-          pkgs = import nixpkgs {
-            inherit system;
-            overlays = [ rust-overlay.overlays.default ];
-          };
+          pkgs = pkgsFor system;
 
           # Project requires nightly Rust (rust-toolchain.toml: nightly-2026-05-24)
           rustToolchain = pkgs.rust-bin.nightly."2026-05-24".minimal;
@@ -49,12 +69,11 @@
             hash = "sha256-pGbCe+Aw2fwZSw+ESZphP3Zymo/NceieTRHzhedGduE=";
           };
 
-          # fspy build.rs downloads these binaries via curl at build time.
-          # Pre-fetch them and provide a curl wrapper to satisfy the sandbox.
-          #
-          # Platform mapping for oils-for-unix and uutils-coreutils.
-          # oils-for-unix only provides macOS binaries; on Linux the build uses
-          # the system-provided oils package instead.
+          # fspy build.rs downloads these binaries via curl at build time, but
+          # only on macOS: build.rs returns early when CARGO_CFG_TARGET_OS is
+          # not "macos", and on Linux fspy uses seccomp-based syscall
+          # interception instead. So no external binaries are fetched or used
+          # on Linux and the entries below are null there.
           platformBinaries = {
             "aarch64-darwin" = {
               oils = {
@@ -76,19 +95,15 @@
                 hash = "sha256-bkvoQp7+hsmmAkeuepMCIe0RdwqXX7S2/Qn/jTm5oVw=";
               };
             };
+            # fspy uses seccomp on Linux, not the macOS preload + bundled
+            # binaries, so nothing is downloaded here.
             "aarch64-linux" = {
-              oils = null; # oils-for-unix does not publish Linux binaries; use system oils
-              coreutils = {
-                url = "https://github.com/uutils/coreutils/releases/download/0.4.0/coreutils-0.4.0-aarch64-unknown-linux-gnu.tar.gz";
-                hash = "sha256-AhoMGXe6FXnV6BMgAiFVibBrSkD7DhtiyZI6c7xy3uU=";
-              };
+              oils = null;
+              coreutils = null;
             };
             "x86_64-linux" = {
-              oils = null; # oils-for-unix does not publish Linux binaries; use system oils
-              coreutils = {
-                url = "https://github.com/uutils/coreutils/releases/download/0.4.0/coreutils-0.4.0-x86_64-unknown-linux-gnu.tar.gz";
-                hash = "sha256-cmgJHJaMeSidiwge2ljnONEvmDrrY8vzBgmvYp+CJVQ=";
-              };
+              oils = null;
+              coreutils = null;
             };
           };
 
@@ -97,7 +112,11 @@
           oils-for-unix =
             if binaries.oils != null then pkgs.fetchurl { inherit (binaries.oils) url hash; } else null;
 
-          uutils-coreutils = pkgs.fetchurl { inherit (binaries.coreutils) url hash; };
+          uutils-coreutils =
+            if binaries.coreutils != null then
+              pkgs.fetchurl { inherit (binaries.coreutils) url hash; }
+            else
+              null;
 
           # Build pnpm dependencies as a separate derivation.
           # The lock file (pnpm/pnpm-lock.yaml) pins exact versions.
@@ -127,25 +146,18 @@
             '';
           };
 
-          fakeCurl = pkgs.writeShellScriptBin "curl" (
-            ''
-              for arg in "$@"; do url="$arg"; done
-              case "$url" in
-            ''
-            + (
-              if oils-for-unix != null then
-                ''
-                  *oils-for-unix*) cat "${oils-for-unix}" ;;
-                ''
-              else
-                ""
-            )
-            + ''
+          # fspy's build.rs fetches the bundled binaries with curl. This only
+          # runs on macOS (fakeCurl is restricted to Darwin in nativeBuildInputs
+          # below), where both oils and coreutils are always present, so no
+          # conditional is needed here.
+          fakeCurl = pkgs.writeShellScriptBin "curl" ''
+            for arg in "$@"; do url="$arg"; done
+            case "$url" in
+              *oils-for-unix*) cat "${oils-for-unix}" ;;
               *coreutils*) cat "${uutils-coreutils}" ;;
-                *) echo "fakeCurl: unknown URL: $url" >&2; exit 1 ;;
-              esac
-            ''
-          );
+              *) echo "fakeCurl: unknown URL: $url" >&2; exit 1 ;;
+            esac
+          '';
 
           # Use cargo vendor directly via a fixed-output derivation.
           # nixpkgs' fetchCargoVendor and importCargoLock both fail when
@@ -163,12 +175,7 @@
             postUnpack = ''
               cp $sourceRoot/Cargo.lock $TMPDIR/original-Cargo.lock
             '';
-            postPatch = ''
-              substituteInPlace Cargo.toml \
-                --replace-fail 'members = ["bench", "crates/*", "packages/cli/binding"]' \
-                               'members = ["crates/*"]'
-              sed -i '/path = "\.\/rolldown\//d' Cargo.toml
-            '';
+            postPatch = patchWorkspace;
             buildPhase = ''
               export HOME=$TMPDIR
               export SSL_CERT_FILE=${pkgs.cacert}/etc/ssl/certs/ca-bundle.crt
@@ -194,17 +201,12 @@
             "-p"
             "vite_global_cli"
           ];
-          nativeBuildInputs = [ fakeCurl ];
 
-          # The workspace references packages/cli/binding which depends on
-          # rolldown/ (not present in the source tree). Remove the member and
-          # all rolldown path dependencies so cargo can resolve the workspace.
-          postPatch = ''
-            substituteInPlace Cargo.toml \
-              --replace-fail 'members = ["bench", "crates/*", "packages/cli/binding"]' \
-                             'members = ["crates/*"]'
-            sed -i '/path = "\.\/rolldown\//d' Cargo.toml
-          '';
+          # fakeCurl is only needed on macOS, where fspy's build.rs downloads
+          # bundled binaries. Linux uses seccomp and fetches nothing.
+          nativeBuildInputs = lib.optionals pkgs.stdenv.isDarwin [ fakeCurl ];
+
+          postPatch = patchWorkspace;
 
           postInstall = ''
             cp -r --no-preserve=mode ${vitePlusNodeModules}/node_modules $out/
@@ -224,42 +226,39 @@
           meta = {
             description = "Unified toolchain for JavaScript";
             homepage = "https://github.com/voidzero-dev/vite-plus";
-            license = pkgs.lib.licenses.mit;
+            license = lib.licenses.mit;
             maintainers = [ { github = "naitokosuke"; } ];
             mainProgram = "vp";
           };
         };
     in
-    let
-      systemOutputs = forAllSystems (
+    {
+      packages = forAllSystems (
         system:
         let
           vp = mkVitePlus system;
+        in
+        {
+          vite-plus = vp;
+          default = vp;
+        }
+      );
+
+      apps = forAllSystems (
+        system:
+        let
           app = {
             type = "app";
-            program = "${vp}/bin/vp";
-            meta = {
-              description = "Unified toolchain for JavaScript";
-              mainProgram = "vp";
-            };
+            program = lib.getExe self.packages.${system}.default;
           };
         in
         {
-          packages = {
-            vite-plus = vp;
-            default = vp;
-          };
-          apps = {
-            vite-plus = app;
-            default = app;
-          };
+          vite-plus = app;
+          default = app;
         }
       );
-    in
-    {
-      packages = nixpkgs.lib.mapAttrs (_: v: v.packages) systemOutputs;
-      apps = nixpkgs.lib.mapAttrs (_: v: v.apps) systemOutputs;
-      formatter = forAllSystems (system: (import nixpkgs { inherit system; }).nixfmt);
+
+      formatter = forAllSystems (system: (pkgsFor system).nixfmt);
 
       overlays.default = final: prev: {
         vite-plus = self.packages.${final.system}.vite-plus;
@@ -268,14 +267,15 @@
       devShells = forAllSystems (
         system:
         let
-          pkgs = import nixpkgs { inherit system; };
+          pkgs = pkgsFor system;
         in
         {
           default = pkgs.mkShell {
+            # Tools for reproducing the automated update locally. The update
+            # workflow itself uses nix-prefetch-url (built into Nix) plus pnpm.
             packages = [
               pkgs.nodejs
-              pkgs.nix-prefetch
-              pkgs.prefetch-npm-deps
+              pkgs.pnpm_10
             ];
           };
         }
@@ -284,11 +284,11 @@
       checks = forAllSystems (
         system:
         let
-          vite-plus = mkVitePlus system;
+          pkgs = pkgsFor system;
         in
         {
-          vite-plus-version = nixpkgs.legacyPackages.${system}.runCommand "vite-plus-version-check" {} ''
-            ${vite-plus}/bin/vp --version
+          vite-plus-version = pkgs.runCommand "vite-plus-version-check" { } ''
+            ${self.packages.${system}.vite-plus}/bin/vp --version
             touch $out
           '';
         }

--- a/flake.nix
+++ b/flake.nix
@@ -27,9 +27,6 @@
 
       forAllSystems = lib.genAttrs supportedSystems;
 
-      # Single source of truth for nixpkgs per system. The rust-overlay is
-      # harmless for the formatter/devShell/checks and keeps every output on
-      # the same package set.
       pkgsFor =
         system:
         import nixpkgs {
@@ -37,10 +34,9 @@
           overlays = [ rust-overlay.overlays.default ];
         };
 
-      # The workspace references packages/cli/binding which depends on
-      # rolldown/ (not present in the source tree). Remove the member and all
-      # rolldown path dependencies so cargo can resolve the workspace. Shared
-      # by the cargo-vendor FOD and the final build so the two cannot drift.
+      # rolldown/ and packages/cli/binding are absent from the published source
+      # tree, so drop them before cargo resolves the workspace. Shared between
+      # the cargo-vendor FOD and the build so the two patches cannot drift.
       patchWorkspace = ''
         substituteInPlace Cargo.toml \
           --replace-fail 'members = ["bench", "crates/*", "packages/cli/binding"]' \
@@ -53,7 +49,7 @@
         let
           pkgs = pkgsFor system;
 
-          # Project requires nightly Rust (rust-toolchain.toml: nightly-2026-05-24)
+          # Pinned nightly from upstream rust-toolchain.toml (synced by update-vp.yml).
           rustToolchain = pkgs.rust-bin.nightly."2026-05-24".minimal;
 
           rustPlatform = pkgs.makeRustPlatform {
@@ -69,11 +65,9 @@
             hash = "sha256-pGbCe+Aw2fwZSw+ESZphP3Zymo/NceieTRHzhedGduE=";
           };
 
-          # fspy build.rs downloads these binaries via curl at build time, but
-          # only on macOS: build.rs returns early when CARGO_CFG_TARGET_OS is
-          # not "macos", and on Linux fspy uses seccomp-based syscall
-          # interception instead. So no external binaries are fetched or used
-          # on Linux and the entries below are null there.
+          # fspy's build.rs only downloads these via curl on macOS; it returns
+          # early on other targets and uses seccomp on Linux, so they are null
+          # there and nothing is fetched.
           platformBinaries = {
             "aarch64-darwin" = {
               oils = {
@@ -95,8 +89,6 @@
                 hash = "sha256-bkvoQp7+hsmmAkeuepMCIe0RdwqXX7S2/Qn/jTm5oVw=";
               };
             };
-            # fspy uses seccomp on Linux, not the macOS preload + bundled
-            # binaries, so nothing is downloaded here.
             "aarch64-linux" = {
               oils = null;
               coreutils = null;
@@ -118,8 +110,6 @@
             else
               null;
 
-          # Build pnpm dependencies as a separate derivation.
-          # The lock file (pnpm/pnpm-lock.yaml) pins exact versions.
           vitePlusNodeModules = pkgs.stdenv.mkDerivation {
             pname = "vite-plus-pnpm-deps";
             inherit version;
@@ -146,10 +136,9 @@
             '';
           };
 
-          # fspy's build.rs fetches the bundled binaries with curl. This only
-          # runs on macOS (fakeCurl is restricted to Darwin in nativeBuildInputs
-          # below), where both oils and coreutils are always present, so no
-          # conditional is needed here.
+          # fspy's build.rs fetches the bundled binaries with curl, which the
+          # sandbox blocks; this wrapper serves the pre-fetched files instead.
+          # Only used on macOS (see nativeBuildInputs), where both are present.
           fakeCurl = pkgs.writeShellScriptBin "curl" ''
             for arg in "$@"; do url="$arg"; done
             case "$url" in
@@ -159,11 +148,9 @@
             esac
           '';
 
-          # Use cargo vendor directly via a fixed-output derivation.
-          # nixpkgs' fetchCargoVendor and importCargoLock both fail when
-          # the same crate name+version appears from crates.io AND a git
-          # source (brush-parser-0.3.0). cargo vendor handles this natively
-          # by appending a hash suffix to disambiguate.
+          # fetchCargoVendor and importCargoLock both choke when the same
+          # crate name+version comes from both crates.io and a git source
+          # (brush-parser-0.3.0); cargo vendor disambiguates with a hash suffix.
           cargoVendorDir = pkgs.stdenv.mkDerivation {
             name = "vite-plus-${version}-cargo-vendor";
             inherit src;
@@ -202,8 +189,6 @@
             "vite_global_cli"
           ];
 
-          # fakeCurl is only needed on macOS, where fspy's build.rs downloads
-          # bundled binaries. Linux uses seccomp and fetches nothing.
           nativeBuildInputs = lib.optionals pkgs.stdenv.isDarwin [ fakeCurl ];
 
           postPatch = patchWorkspace;
@@ -211,11 +196,9 @@
           postInstall = ''
             cp -r --no-preserve=mode ${vitePlusNodeModules}/node_modules $out/
 
-            # Files in the Nix store are pinned to 0444 by fixupPhase.
-            # `vp create` copies templates with fs.copyFileSync, which
-            # preserves the source mode, so the destination ends up 0444
-            # and the subsequent editJsonFile call fails with EACCES.
-            # Patch the copy helper to chmod each file to 0644 right after.
+            # The store pins files to 0444, but `vp create` copies templates
+            # with fs.copyFileSync (mode-preserving) and then editJsonFile fails
+            # with EACCES on the read-only copy. Chmod each copied file to 0644.
             substituteInPlace $out/node_modules/vite-plus/dist/create/bin.js \
               --replace-fail 'else fs.copyFileSync(src, dest);' \
                              'else { fs.copyFileSync(src, dest); fs.chmodSync(dest, 0o644); }'
@@ -271,8 +254,6 @@
         in
         {
           default = pkgs.mkShell {
-            # Tools for reproducing the automated update locally. The update
-            # workflow itself uses nix-prefetch-url (built into Nix) plus pnpm.
             packages = [
               pkgs.nodejs
               pkgs.pnpm_10
@@ -288,6 +269,9 @@
         in
         {
           vite-plus-version = pkgs.runCommand "vite-plus-version-check" { } ''
+            # vp builds an HTTPS client on startup and aborts when no CA certs
+            # are found (a hard error on Linux), so point it at a bundle.
+            export SSL_CERT_FILE=${pkgs.cacert}/etc/ssl/certs/ca-bundle.crt
             ${self.packages.${system}.vite-plus}/bin/vp --version
             touch $out
           '';


### PR DESCRIPTION
Inspected the flake / CI / docs, which had grown redundant through incremental edits, and tidied them up to match current practice. This single PR addresses the issues filed earlier.

On aarch64-darwin, `nix flake check` confirms the built artifact is unchanged (`vp v0.1.24` runs, version check passes). The x86_64-linux build is verified for the first time by this PR's CI (ubuntu-latest).

## Changes

### `flake.nix`
- **#78** Factor the duplicated Cargo.toml workspace patch into a shared `patchWorkspace` binding used by both the cargo-vendor FOD and the build, so the two can no longer drift.
- **#79** Unify all nixpkgs imports behind a single `pkgsFor` helper; `checks` now reuses `self.packages.<system>.vite-plus` instead of re-evaluating `mkVitePlus`.
- **#80** Drop the hand-rolled `systemOutputs` + `mapAttrs` indirection and the double `let`; define `packages`/`apps` directly via `forAllSystems`, and derive `apps` from `lib.getExe` (removing the duplicated app meta).
- **#37** Null out the Linux platform binaries and restrict `fakeCurl` to Darwin: fspy only downloads bundled binaries on macOS and uses seccomp on Linux, so the Linux coreutils fetch was unused. The now-dead oils conditional inside `fakeCurl` is removed.
- **#35** Replace the unused devShell tools (`nix-prefetch`, `prefetch-npm-deps`) with `pnpm_10`, matching the pnpm-based build.

### `.github/workflows/ci.yml`
- **#36** Replace `nix build` + `nix run` with `nix flake check` (the version check already runs `vp --version`), enable the x86_64-linux runner, and make `ci-complete` also fail on a `changes`-job failure.

### `README.md`
- **#83** Rewrite the npm-era sections (`package-lock.json` / `npmDepsHash` / `prefetch-npm-deps` / `buildNpmPackage`) for the pnpm + cargo-vendor reality, and correct the supported-platform description.

## Verification
- `nix fmt` applied
- `nix flake show --all-systems` evaluates cleanly across all four systems
- `nix flake check` (aarch64-darwin) exits 0; `vp v0.1.24` runs

## Notes
- #3 (Publish nixpkgs) is out of scope and kept as a future goal.
- The x86_64-linux build cannot be verified locally (on darwin), so this PR's CI is its first check. If it fails, the Linux handling in #37 / #36 will be followed up.

Closes #78
Closes #79
Closes #80
Closes #83
Closes #35
Closes #36
Closes #37

🤖 Generated with [Claude Code](https://claude.com/claude-code)
