### PR TITLE
feat: build vite-plus from upstream prebuilt npm binaries (drop Rust build)

### DIFF
--- a/.github/workflows/update-vp.yml
+++ b/.github/workflows/update-vp.yml
@@ -82,55 +82,8 @@ jobs:
           # Use GNU sed via Nix for compatibility with macOS
           GSED="nix run nixpkgs#gnused --"
 
-          # Sync the pinned Rust toolchain with upstream rust-toolchain.toml.
-          # vite-plus bumps its required nightly from time to time (e.g. v0.1.23
-          # moved to nightly-2026-05-24 for the c_variadic VaList::next_arg API).
-          # Without this, the new version fails to compile against a stale
-          # toolchain and the "Verify build" step below fails.
-          echo "Syncing Rust toolchain from upstream rust-toolchain.toml..."
-          RUST_CHANNEL=$(gh api "repos/voidzero-dev/vite-plus/contents/rust-toolchain.toml?ref=v${NEW_VERSION}" \
-            -H "Accept: application/vnd.github.raw" \
-            | grep -E '^channel' \
-            | sed -E 's/.*"nightly-([0-9]{4}-[0-9]{2}-[0-9]{2})".*/\1/')
-          if [ -z "$RUST_CHANNEL" ]; then
-            echo "Error: Could not determine Rust nightly channel from upstream rust-toolchain.toml"
-            exit 1
-          fi
-          echo "Upstream Rust nightly channel: nightly-$RUST_CHANNEL"
-
-          CURRENT_CHANNEL=$(grep -oE 'nightly\."[0-9]{4}-[0-9]{2}-[0-9]{2}"' flake.nix | head -1 | grep -oE '[0-9]{4}-[0-9]{2}-[0-9]{2}')
-          if [ "$CURRENT_CHANNEL" != "$RUST_CHANNEL" ]; then
-            echo "Updating Rust toolchain pin: nightly-$CURRENT_CHANNEL -> nightly-$RUST_CHANNEL"
-            # Update both the documenting comment (nightly-DATE) and the pin (nightly."DATE")
-            $GSED -i -E "s|nightly-[0-9]{4}-[0-9]{2}-[0-9]{2}|nightly-$RUST_CHANNEL|g" flake.nix
-            $GSED -i -E "s|nightly\.\"[0-9]{4}-[0-9]{2}-[0-9]{2}\"|nightly.\"$RUST_CHANNEL\"|" flake.nix
-            # Refresh rust-overlay so the new nightly toolchain is available
-            nix flake update rust-overlay
-          else
-            echo "Rust toolchain already up to date (nightly-$RUST_CHANNEL)"
-          fi
-
           # Update version (only first occurrence)
           $GSED -i "0,/version = \"[^\"]*\"/s//version = \"$NEW_VERSION\"/" flake.nix
-
-          # Get new source hash
-          echo "Fetching hash for version $NEW_VERSION..."
-          PREFETCH_HASH=$(nix-prefetch-url --unpack "https://github.com/voidzero-dev/vite-plus/archive/refs/tags/v${NEW_VERSION}.tar.gz")
-          if [ -z "$PREFETCH_HASH" ]; then
-            echo "Error: Failed to prefetch source"
-            exit 1
-          fi
-          NEW_HASH=$(nix hash to-sri --type sha256 "$PREFETCH_HASH")
-          if [ -z "$NEW_HASH" ]; then
-            echo "Error: Failed to convert hash to SRI format"
-            exit 1
-          fi
-          echo "Got hash: $NEW_HASH"
-
-          # Update source hash (only first occurrence)
-          $GSED -i "0,/hash = \"sha256-[^\"]*\"/s||hash = \"$NEW_HASH\"|" flake.nix
-
-          echo "Updated source to version $NEW_VERSION with hash $NEW_HASH"
 
           # Update pnpm/package.json and pnpm-lock.yaml for the new version
           echo "Updating pnpm dependencies for version $NEW_VERSION..."
@@ -143,7 +96,7 @@ jobs:
           #   error: hash mismatch in fixed-output derivation '/nix/store/...-<name>-...':
           #            specified: sha256-...
           #               got:    sha256-...
-          # Args: $1 = pattern to identify the FOD (e.g. "pnpm-deps" or "cargo-vendor")
+          # Args: $1 = pattern to identify the FOD (e.g. "pnpm-deps")
           extract_hash() {
             local pattern="$1"
             local output
@@ -158,9 +111,8 @@ jobs:
 
           FAKE_HASH="sha256-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA="
 
-          # Step 1: Compute pnpmDepsHash
-          # Invalidate only pnpmDepsHash; cargoVendorHash stays correct so
-          # nix reports exactly one hash mismatch for the pnpm FOD.
+          # Compute pnpmDepsHash: set a fake hash so the build fails with a
+          # mismatch that reports the real one, then write it back.
           $GSED -i "s|hash = \"sha256-[^\"]*\"; # pnpmDepsHash|hash = \"$FAKE_HASH\"; # pnpmDepsHash|" flake.nix
           PNPM_DEPS_HASH=$(extract_hash "pnpm-deps")
           if [ -z "$PNPM_DEPS_HASH" ]; then
@@ -169,18 +121,6 @@ jobs:
           fi
           $GSED -i "s|hash = \"sha256-[^\"]*\"; # pnpmDepsHash|hash = \"$PNPM_DEPS_HASH\"; # pnpmDepsHash|" flake.nix
           echo "Updated pnpmDepsHash to $PNPM_DEPS_HASH"
-
-          # Step 2: Compute cargoVendorHash
-          # pnpmDepsHash is now correct. Invalidate only cargoVendorHash so
-          # nix reports exactly one hash mismatch for the cargo vendor FOD.
-          $GSED -i "s|outputHash = \"sha256-[^\"]*\"; # cargoVendorHash|outputHash = \"$FAKE_HASH\"; # cargoVendorHash|" flake.nix
-          CARGO_VENDOR_HASH=$(extract_hash "cargo-vendor")
-          if [ -z "$CARGO_VENDOR_HASH" ]; then
-            echo "Error: Failed to compute cargoVendorHash"
-            exit 1
-          fi
-          $GSED -i "s|outputHash = \"sha256-[^\"]*\"; # cargoVendorHash|outputHash = \"$CARGO_VENDOR_HASH\"; # cargoVendorHash|" flake.nix
-          echo "Updated cargoVendorHash to $CARGO_VENDOR_HASH"
 
       - name: Update CHANGELOG.md
         if: steps.check.outputs.needs_update == 'true'
@@ -222,9 +162,9 @@ jobs:
 
       # When no update is needed the steps above are skipped, so the scheduled
       # run would report success without ever building anything. Always verify
-      # that the currently pinned version still builds, so toolchain drift
-      # (e.g. upstream requiring a newer nightly than flake.nix pins) is caught
-      # here instead of silently passing.
+      # that the currently pinned version still builds, so upstream breakage
+      # (e.g. a yanked prebuilt or a moved dependency) is caught here instead
+      # of silently passing.
       - name: Verify current build
         if: steps.check.outputs.needs_update == 'false'
         run: |
@@ -247,7 +187,7 @@ jobs:
 
             ### Changes
             - Updated version in `flake.nix`
-            - Updated source hash, `pnpmDepsHash`, and `cargoVendorHash`
+            - Updated `pnpmDepsHash`
             - Updated `pnpm/package.json` and `pnpm-lock.yaml`
             - Updated `CHANGELOG.md`
 

--- a/README.md
+++ b/README.md
@@ -34,19 +34,17 @@ nix profile install github:naitokosuke/vp-nix
 
 A GitHub Actions workflow (`update-vp.yml`) runs every 12 hours to check for new vite-plus releases. When a new version is found it:
 
-1. Updates the version and source hash in `flake.nix`
-2. Syncs the pinned Rust nightly toolchain with the upstream `rust-toolchain.toml`
-3. Updates `pnpm/package.json` and `pnpm/pnpm-lock.yaml`
-4. Recomputes `pnpmDepsHash` and `cargoVendorHash`
-5. Updates `CHANGELOG.md`
-6. Verifies the build passes and opens a pull request automatically
+1. Updates the version in `flake.nix`
+2. Updates `pnpm/package.json` and `pnpm/pnpm-lock.yaml`
+3. Recomputes `pnpmDepsHash`
+4. Updates `CHANGELOG.md`
+5. Verifies the build passes and opens a pull request automatically
 
-## Why the pnpm and vendoring files live in this repository
+## Why the pnpm files live in this repository
 
-Nix builds run inside a sandbox with no network access, so all dependencies must be fetched as fixed-output derivations before the build.
+Nix builds run inside a sandbox with no network access, so all dependencies must be fetched as a fixed-output derivation before the build. `fetchPnpmDeps` needs a lock file to produce a reproducible `node_modules` (`pnpmDepsHash`). Because upstream does not ship a lock file suitable for this purpose, this flake maintains its own `pnpm/package.json` / `pnpm/pnpm-lock.yaml` pinning the vite-plus package.
 
-- **JavaScript deps:** `fetchPnpmDeps` needs a lock file to produce a reproducible `node_modules` (`pnpmDepsHash`). Because upstream does not ship a lock file suitable for this purpose, this flake maintains its own `pnpm/package.json` / `pnpm/pnpm-lock.yaml` pinning the vite-plus package.
-- **Rust deps:** crates are vendored with `cargo vendor` into a fixed-output derivation (`cargoVendorHash`); this handles a crate that appears from both crates.io and a git source, which the nixpkgs `fetchCargoVendor`/`importCargoLock` helpers cannot.
+vite-plus ships its native binary as prebuilt per-platform npm packages (`@voidzero-dev/vite-plus-<platform>`) that pnpm fetches as part of those deps, so the flake just wraps the prebuilt launcher under a pinned Node.js and needs no Rust toolchain.
 
 The automated update workflow keeps all of these in sync whenever a new version is released.
 

--- a/flake.lock
+++ b/flake.lock
@@ -18,28 +18,7 @@
     },
     "root": {
       "inputs": {
-        "nixpkgs": "nixpkgs",
-        "rust-overlay": "rust-overlay"
-      }
-    },
-    "rust-overlay": {
-      "inputs": {
-        "nixpkgs": [
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1781666412,
-        "narHash": "sha256-Tzgol+o9+V4lK99r4AERI4pyFoZwg6Si2xUd1wc/WQU=",
-        "owner": "oxalica",
-        "repo": "rust-overlay",
-        "rev": "d0e019d9543f0f1215a3d961fc4dca59aa29c638",
-        "type": "github"
-      },
-      "original": {
-        "owner": "oxalica",
-        "repo": "rust-overlay",
-        "type": "github"
+        "nixpkgs": "nixpkgs"
       }
     }
   },

--- a/flake.nix
+++ b/flake.nix
@@ -3,18 +3,10 @@
 
   inputs = {
     nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
-    rust-overlay = {
-      url = "github:oxalica/rust-overlay";
-      inputs.nixpkgs.follows = "nixpkgs";
-    };
   };
 
   outputs =
-    {
-      self,
-      nixpkgs,
-      rust-overlay,
-    }:
+    { self, nixpkgs }:
     let
       inherit (nixpkgs) lib;
 
@@ -27,91 +19,21 @@
 
       forAllSystems = lib.genAttrs supportedSystems;
 
-      pkgsFor =
-        system:
-        import nixpkgs {
-          inherit system;
-          overlays = [ rust-overlay.overlays.default ];
-        };
-
-      # rolldown/ and packages/cli/binding are absent from the published source
-      # tree, so drop them before cargo resolves the workspace. Shared between
-      # the cargo-vendor FOD and the build so the two patches cannot drift.
-      patchWorkspace = ''
-        substituteInPlace Cargo.toml \
-          --replace-fail 'members = ["bench", "crates/*", "packages/cli/binding"]' \
-                         'members = ["crates/*"]'
-        sed -i '/path = "\.\/rolldown\//d' Cargo.toml
-      '';
+      pkgsFor = system: nixpkgs.legacyPackages.${system};
 
       mkVitePlus =
         system:
         let
           pkgs = pkgsFor system;
-
-          # Pinned nightly from upstream rust-toolchain.toml (synced by update-vp.yml).
-          rustToolchain = pkgs.rust-bin.nightly."2026-06-10".minimal;
-
-          rustPlatform = pkgs.makeRustPlatform {
-            cargo = rustToolchain;
-            rustc = rustToolchain;
-          };
-
+          nodejs = pkgs.nodejs_24;
           version = "0.2.0";
-          src = pkgs.fetchFromGitHub {
-            owner = "voidzero-dev";
-            repo = "vite-plus";
-            rev = "v${version}";
-            hash = "sha256-tn9oclrxtnHMlUTQB7GUAzXhRwOvwsM5L/Z+735edeM=";
-          };
 
-          # fspy's build.rs only downloads these via curl on macOS; it returns
-          # early on other targets and uses seccomp on Linux, so they are null
-          # there and nothing is fetched.
-          platformBinaries = {
-            "aarch64-darwin" = {
-              oils = {
-                url = "https://github.com/branchseer/oils-for-unix-build/releases/download/oils-for-unix-0.37.0/oils-for-unix-0.37.0-darwin-arm64.tar.gz";
-                hash = "sha256-OjX3rivoX80yOSzYFxUi9YIvIKaRJcXp2NaLL1yFcJg=";
-              };
-              coreutils = {
-                url = "https://github.com/uutils/coreutils/releases/download/0.4.0/coreutils-0.4.0-aarch64-apple-darwin.tar.gz";
-                hash = "sha256-oUi2YO6vQJr3pEBpA/k9DmcTpeua3K9xodcy8ePMNSI=";
-              };
-            };
-            "x86_64-darwin" = {
-              oils = {
-                url = "https://github.com/branchseer/oils-for-unix-build/releases/download/oils-for-unix-0.37.0/oils-for-unix-0.37.0-darwin-x86_64.tar.gz";
-                hash = "sha256-qhIljRvVUwIBRK1h/awY59++P8OWXaMu5FiEAVMWkVE=";
-              };
-              coreutils = {
-                url = "https://github.com/uutils/coreutils/releases/download/0.4.0/coreutils-0.4.0-x86_64-apple-darwin.tar.gz";
-                hash = "sha256-bkvoQp7+hsmmAkeuepMCIe0RdwqXX7S2/Qn/jTm5oVw=";
-              };
-            };
-            "aarch64-linux" = {
-              oils = null;
-              coreutils = null;
-            };
-            "x86_64-linux" = {
-              oils = null;
-              coreutils = null;
-            };
-          };
-
-          binaries = platformBinaries.${system};
-
-          oils-for-unix =
-            if binaries.oils != null then pkgs.fetchurl { inherit (binaries.oils) url hash; } else null;
-
-          uutils-coreutils =
-            if binaries.coreutils != null then
-              pkgs.fetchurl { inherit (binaries.coreutils) url hash; }
-            else
-              null;
-
-          vitePlusNodeModules = pkgs.stdenv.mkDerivation {
-            pname = "vite-plus-pnpm-deps";
+          # Upstream ships prebuilt per-platform binaries on npm via
+          # optionalDependencies (@voidzero-dev/vite-plus-<platform>: a napi
+          # .node plus a JS bin/vp launcher). pnpm fetches the one matching the
+          # build platform, so no Rust toolchain / cargo build is needed.
+          nodeModules = pkgs.stdenv.mkDerivation {
+            pname = "vite-plus-node-modules";
             inherit version;
             src = ./pnpm;
 
@@ -121,7 +43,7 @@
             ];
 
             pnpmDeps = pkgs.fetchPnpmDeps {
-              pname = "vite-plus-pnpm-deps";
+              pname = "vite-plus-node-modules";
               inherit version;
               src = ./pnpm;
               hash = "sha256-Y8JpqrC3jbtfH08INv9GhBArnALoBE9P5blLcIuKwJ4="; # pnpmDepsHash
@@ -135,76 +57,37 @@
               cp -r node_modules $out/
             '';
           };
-
-          # fspy's build.rs fetches the bundled binaries with curl, which the
-          # sandbox blocks; this wrapper serves the pre-fetched files instead.
-          # Only used on macOS (see nativeBuildInputs), where both are present.
-          fakeCurl = pkgs.writeShellScriptBin "curl" ''
-            for arg in "$@"; do url="$arg"; done
-            case "$url" in
-              *oils-for-unix*) cat "${oils-for-unix}" ;;
-              *coreutils*) cat "${uutils-coreutils}" ;;
-              *) echo "fakeCurl: unknown URL: $url" >&2; exit 1 ;;
-            esac
-          '';
-
-          # fetchCargoVendor and importCargoLock both choke when the same
-          # crate name+version comes from both crates.io and a git source
-          # (brush-parser-0.3.0); cargo vendor disambiguates with a hash suffix.
-          cargoVendorDir = pkgs.stdenv.mkDerivation {
-            name = "vite-plus-${version}-cargo-vendor";
-            inherit src;
-            nativeBuildInputs = [
-              rustToolchain
-              pkgs.git
-              pkgs.cacert
-            ];
-            postUnpack = ''
-              cp $sourceRoot/Cargo.lock $TMPDIR/original-Cargo.lock
-            '';
-            postPatch = patchWorkspace;
-            buildPhase = ''
-              export HOME=$TMPDIR
-              export SSL_CERT_FILE=${pkgs.cacert}/etc/ssl/certs/ca-bundle.crt
-              vendorConfig=$(cargo -Z bindeps vendor $out)
-              mkdir -p $out/.cargo
-              echo "$vendorConfig" | sed "s|$out|@vendor@|g" > $out/.cargo/config.toml
-              cp $TMPDIR/original-Cargo.lock $out/Cargo.lock
-            '';
-            dontInstall = true;
-            dontFixup = true;
-            outputHashMode = "recursive";
-            outputHashAlgo = "sha256";
-            outputHash = "sha256-Z3nzxdC5i999gqgIibD6EHYPpO1NWhEdAThbbzwDVA0="; # cargoVendorHash
-          };
-
         in
-        rustPlatform.buildRustPackage {
+        pkgs.stdenv.mkDerivation {
           pname = "vite-plus";
-          inherit version src;
-          cargoDeps = cargoVendorDir;
+          inherit version;
 
-          cargoBuildFlags = [
-            "-p"
-            "vite_global_cli"
-          ];
+          dontUnpack = true;
 
-          nativeBuildInputs = lib.optionals pkgs.stdenv.isDarwin [ fakeCurl ];
+          nativeBuildInputs = [ pkgs.makeWrapper ];
 
-          postPatch = patchWorkspace;
+          installPhase = ''
+            runHook preInstall
 
-          postInstall = ''
-            cp -r --no-preserve=mode ${vitePlusNodeModules}/node_modules $out/
+            mkdir -p $out/lib $out/bin
+            cp -r ${nodeModules}/node_modules $out/lib/node_modules
 
             # The store pins files to 0444, but `vp create` copies templates
             # with fs.copyFileSync (mode-preserving) and then editJsonFile fails
             # with EACCES on the read-only copy. Chmod each copied file to 0644.
-            substituteInPlace $out/node_modules/vite-plus/dist/create/bin.js \
+            substituteInPlace $out/lib/node_modules/vite-plus/dist/create/bin.js \
               --replace-fail 'else fs.copyFileSync(src, dest);' \
                              'else { fs.copyFileSync(src, dest); fs.chmodSync(dest, 0o644); }'
-          '';
 
-          doCheck = false;
+            # The published bin entries are `#!/usr/bin/env node` launchers; wrap
+            # them to run under this pinned nodejs without relying on PATH.
+            for b in vp oxfmt oxlint; do
+              makeWrapper ${nodejs}/bin/node $out/bin/$b \
+                --add-flags $out/lib/node_modules/vite-plus/bin/$b
+            done
+
+            runHook postInstall
+          '';
 
           meta = {
             description = "Unified toolchain for JavaScript";
@@ -255,7 +138,7 @@
         {
           default = pkgs.mkShell {
             packages = [
-              pkgs.nodejs
+              pkgs.nodejs_24
               pkgs.pnpm_10
             ];
           };

--- a/flake.nix
+++ b/flake.nix
@@ -79,8 +79,6 @@
               --replace-fail 'else fs.copyFileSync(src, dest);' \
                              'else { fs.copyFileSync(src, dest); fs.chmodSync(dest, 0o644); }'
 
-            # The published bin entries are `#!/usr/bin/env node` launchers; wrap
-            # them to run under this pinned nodejs without relying on PATH.
             for b in vp oxfmt oxlint; do
               makeWrapper ${nodejs}/bin/node $out/bin/$b \
                 --add-flags $out/lib/node_modules/vite-plus/bin/$b


### PR DESCRIPTION
## Summary

Build vite-plus from the prebuilt per-platform binaries upstream publishes on npm, instead of compiling from Rust source.

vite-plus ships its native binary on npm via optionalDependencies (`@voidzero-dev/vite-plus-<platform>`: a napi `.node` plus a JS `bin/vp` launcher), which pnpm already fetches for the build platform. This flake previously built that same binary from source **and** fetched those npm deps — so the entire Rust build was redundant. Now we just wrap the prebuilt launcher under a pinned `nodejs_24`.

## Changes

- **feat**: rewrite the build to wrap the prebuilt npm binary. Removes the `rust-overlay` input, the pinned nightly toolchain, `makeRustPlatform`, the `fetchFromGitHub` source, the oils/coreutils `platformBinaries` table, `fakeCurl`, the cargo-vendor FOD (`cargoVendorHash`) and the workspace patch. The only remaining hash is `pnpmDepsHash`.
- **refactor**: drop the one comment the `makeWrapper` call already makes obvious.
- **ci**: simplify `update-vp.yml` to match (no more rust-toolchain sync, source-hash prefetch, or `cargoVendorHash` recompute).

`flake.nix`: 281 → 162 lines. This also removes the Rust-nightly-drift class of CI failures (#70 / #73 / #76).

## Verification

- `nix build .#packages.aarch64-darwin.default` succeeds with **no Rust toolchain**.
- The wrapped `vp` runs (`vp v0.2.0`), `vp --help` shows the full command set, and the napi `.node` is bundled.
- The flake's `checks.aarch64-darwin.vite-plus-version` (sandboxed `vp --version`) passes.
- `update-vp.yml` is valid YAML; the `pnpmDepsHash` extraction step is unchanged and the pnpm FOD keeps the `…-pnpm-deps` name its grep anchors on.

## Scope / caveats

- Only **aarch64-darwin** was built locally. CI (`ci.yml`) also builds **x86_64-linux**. x86_64-darwin and aarch64-linux have no standard GitHub-hosted runners so they are not built in CI, but are structurally identical (pnpm fetches each platform's `.node`).
- Trade-off: `vp` is now a node-runtime wrapper (pinned `nodejs_24`) rather than a standalone Rust binary. The tool already required `node_modules`, so this is not a new runtime dependency in practice.
- The simplified workflow's hash-recompute path can only be fully exercised by a real scheduled run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

